### PR TITLE
Adding to the Overmocked class

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -154,3 +154,4 @@ dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
 dotnet_style_qualification_for_property = false:silent
 dotnet_style_qualification_for_method = false:silent
 dotnet_style_qualification_for_event = false:silent
+indent_style = space

--- a/src/Kimono.Extensions.DependencyInjection/Kimono.Extensions.DependencyInjection.csproj
+++ b/src/Kimono.Extensions.DependencyInjection/Kimono.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<Version>0.0.5</Version>
+	<Version>0.0.6-RC01</Version>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Kimono/IInvocationContext.cs
+++ b/src/Kimono/IInvocationContext.cs
@@ -8,7 +8,7 @@ namespace Kimono
 	public interface IInvocationContext : IFluentInterface
 	{
 		/// <summary>
-		/// Gets a value indicating whether <see cref="InvokeTarget(bool)"/> has been called previously.
+		/// Gets a value indicating whether <see cref="Invoke(bool,bool)"/> has been called previously.
 		/// </summary>
 		/// <value><c>true</c> if [target invoked]; otherwise, <c>false</c>.</value>
 		public bool TargetInvoked { get; }

--- a/src/Kimono/Intercept.NoTarget.cs
+++ b/src/Kimono/Intercept.NoTarget.cs
@@ -59,7 +59,7 @@ namespace Kimono
 
 			var handler = builder.Build();
 
-			return new SingleHandlerInterceptor<TInterface>(handler);
+			return new HandlerInterceptor<TInterface>(handler);
 		}
 	}
 }

--- a/src/Kimono/Interceptors/HandlerInterceptor.cs
+++ b/src/Kimono/Interceptors/HandlerInterceptor.cs
@@ -8,15 +8,15 @@ namespace Kimono.Interceptors
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
 	/// <seealso cref="Kimono.Interceptor{T}" />
-	public class SingleHandlerInterceptor<T> : Interceptor<T> where T : class
+	public class HandlerInterceptor<T> : Interceptor<T> where T : class
 	{
 		private readonly IInvocationHandler _handler;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="SingleHandlerInterceptor{T}"/> class.
+		/// Initializes a new instance of the <see cref="HandlerInterceptor{T}"/> class.
 		/// </summary>
 		/// <param name="handler">The handler.</param>
-		public SingleHandlerInterceptor(IInvocationHandler handler)
+		public HandlerInterceptor(IInvocationHandler handler)
 		{
 			_handler = handler;
 		}

--- a/src/Kimono/Interceptors/HandlersInterceptor.cs
+++ b/src/Kimono/Interceptors/HandlersInterceptor.cs
@@ -1,21 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Kimono.Interceptors
 {
-    /// <summary>
-    /// Class HandlersInterceptor.
-    /// Implements the <see cref="Interceptor{T}" />
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <seealso cref="Interceptor{T}" />
-    public class HandlersInterceptor<T> : Interceptor<T> where T : class
+	/// <summary>
+	/// Class HandlersInterceptor.
+	/// Implements the <see cref="Interceptor{T}" />
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <seealso cref="Interceptor{T}" />
+	public class HandlersInterceptor<T> : Interceptor<T> where T : class
     {
         private readonly Lazy<IInvocationHandler[]> _interceptorsLazy;
 

--- a/src/Kimono/Interceptors/TargetedSingleHandlerInterceptor.cs
+++ b/src/Kimono/Interceptors/TargetedSingleHandlerInterceptor.cs
@@ -8,7 +8,7 @@ namespace Kimono.Interceptors
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
 	/// <seealso cref="Kimono.Interceptor{T}" />
-	public class TargetedSingleHandlerInterceptor<T> : SingleHandlerInterceptor<T> where T : class
+	public class TargetedSingleHandlerInterceptor<T> : HandlerInterceptor<T> where T : class
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="TargetedSingleHandlerInterceptor{T}"/> class.

--- a/src/Kimono/Kimono.csproj
+++ b/src/Kimono/Kimono.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.0.5</Version>
+    <Version>0.0.6-RC01</Version>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Kimono/Runtime/RuntimeContext.cs
+++ b/src/Kimono/Runtime/RuntimeContext.cs
@@ -7,17 +7,8 @@ namespace Kimono
     /// </summary>
     public struct RuntimeContext
 	{
-		/// <summary>
-		/// The proxied member
-		/// </summary>
 		private readonly IProxyMember _proxiedMember;
-		/// <summary>
-		/// The parameters
-		/// </summary>
 		private readonly List<RuntimeParameter> _parameters;
-		/// <summary>
-		/// The invoke target handler
-		/// </summary>
 		private readonly Func<object, object[]?, object?> _invokeTargetHandler;
 
 		/// <summary>
@@ -51,31 +42,16 @@ namespace Kimono
 		/// <value>The proxied member.</value>
 		public IProxyMember ProxiedMember => _proxiedMember;
 
-		/// <summary>
-		/// Creates the invocation context.
-		/// </summary>
-		/// <param name="interceptor">The interceptor.</param>
-		/// <param name="parameters">The parameters.</param>
-		/// <returns>InvocationContext.</returns>
 		internal InvocationContext CreateInvocationContext(IInterceptor interceptor, object[] parameters)
 		{
 			return new InvocationContext(this, interceptor,  parameters);
 		}
 
-		/// <summary>
-		/// Gets the target invocation handler.
-		/// </summary>
-		/// <returns>Func&lt;System.Object, System.Nullable&lt;System.Object&gt;[], System.Nullable&lt;System.Object&gt;&gt;.</returns>
 		internal Func<object, object[]?, object?> GetTargetInvocationHandler()
 		{
 			return _invokeTargetHandler;
 		}
 
-		/// <summary>
-		/// Maps the parameters.
-		/// </summary>
-		/// <param name="parameters">The parameters.</param>
-		/// <returns>Parameters.</returns>
 		internal Parameters MapParameters(object[] parameters)
 		{
 			return new Parameters(_parameters.ToArray(), parameters);

--- a/src/Overmock.Tests/Examples/ExampleTestsForReadMe.cs
+++ b/src/Overmock.Tests/Examples/ExampleTestsForReadMe.cs
@@ -49,7 +49,7 @@
             var id = 22;
             var wasSaved = false;
             var log = Overmocked.ExpectAnyInvocation<ILog>();
-            var repository = Overmocked.Interface<IRepository>();
+            var repository = Overmocked.Overmock<IRepository>();
 
             repository.Override(r => r.Save(Its.Any<Model>())).ToCall(c =>
             {
@@ -68,7 +68,7 @@
         {
             var expected = "Failed to save";
             var log = Overmocked.ExpectAnyInvocation<ILog>();
-            var repository = Overmocked.Interface<IRepository>();
+            var repository = Overmocked.Overmock<IRepository>();
 
             repository.Override(r => r.Save(Its.Any<Model>())).ToThrow(new Exception(expected));
 

--- a/src/Overmock.Tests/MethodGenericNoParameters.Tests.cs
+++ b/src/Overmock.Tests/MethodGenericNoParameters.Tests.cs
@@ -11,7 +11,7 @@ namespace Overmock.Tests
 		[TestInitialize]
 		public void Initialize()
 		{
-			_genericMethodsTestInterface = Overmocked.Interface<IGenericMethodsTestInterface>();
+			_genericMethodsTestInterface = Overmocked.Overmock<IGenericMethodsTestInterface>();
 		}
 
 		[TestMethod]

--- a/src/Overmock.Tests/MethodWithNoParams.Tests.cs
+++ b/src/Overmock.Tests/MethodWithNoParams.Tests.cs
@@ -15,13 +15,13 @@ namespace Overmock.Tests
 		[TestInitialize]
 		public void Initialize()
 		{
-            _testInterface = Overmocked.Interface<IMethodsWithNoParameters>();
+            _testInterface = Overmocked.Overmock<IMethodsWithNoParameters>();
 		}
 
 		[TestMethod]
 		public void MethodWith2Params()
 		{
-			var overmock = Overmocked.Interface<IMethodsWith2Parameters>();
+			var overmock = Overmocked.Overmock<IMethodsWith2Parameters>();
 
 			overmock.Override(p => p.BoolMethodWithStringAndModel(Its.Any<string>(), Its.Any<Model>()))
 				.ToCall(c => c.Get<string>("name"));

--- a/src/Overmock.Tests/MixedMethodsAndProperties.Tests.cs
+++ b/src/Overmock.Tests/MixedMethodsAndProperties.Tests.cs
@@ -10,7 +10,7 @@ namespace Overmock.Tests
 		{
 			var called = false;
 
-			var overmock = Overmocked.Interface<IInterfaceWithBothMethodsAndProperties>();
+			var overmock = Overmocked.Overmock<IInterfaceWithBothMethodsAndProperties>();
 			overmock.Override(t => t.MethodWithReturn(Its.Any<string>()))
 				.ToCall(c => {
 					called = true;

--- a/src/Overmock.Tests/OvermockedMock/MethodGenericNoParameters.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/MethodGenericNoParameters.Tests.cs
@@ -1,0 +1,31 @@
+﻿using Overmock.Tests.Mocks;
+using Overmock.Tests.Mocks.Methods;
+
+namespace Overmock.Tests.OvermockedMock
+{
+    [TestClass]
+	public partial class GenericMethodNoParametersTests
+	{
+		private IGenericMethodsTestInterface _genericMethodsTestInterface = null!;
+
+		[TestInitialize]
+		public void Initialize()
+		{
+			_genericMethodsTestInterface = Overmocked.For<IGenericMethodsTestInterface>();
+		}
+
+		[TestMethod]
+		public void TestWithGenericParametersOnMethod()
+		{
+			var expected = new List<Model> { new  Model() };
+
+            Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWithNoParamsAndReturnsEnumerableOfT<Model>())
+				.ToReturn(expected);
+
+			var actual = _genericMethodsTestInterface.MethodWithNoParamsAndReturnsEnumerableOfT<Model>();
+			Assert.IsTrue(true);
+			Assert.IsNotNull(actual);
+			CollectionAssert.AreEqual(expected, actual.ToList());
+		}
+	}
+}

--- a/src/Overmock.Tests/OvermockedMock/MethodGenericNoParameters.ToCall.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/MethodGenericNoParameters.ToCall.Tests.cs
@@ -1,0 +1,43 @@
+﻿using Overmock.Tests.Mocks;
+
+namespace Overmock.Tests.OvermockedMock
+{
+	public partial class GenericMethodNoParametersTests
+	{
+		[TestMethod]
+		public void MethodWithNoParamsToCallTest()
+		{
+			Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWithNoParamsAndReturnsEnumerableOfT<Model>())
+				.ToReturn(() => Enumerable.Empty<Model>());
+
+			_genericMethodsTestInterface.MethodWithNoParamsAndReturnsEnumerableOfT<Model>();
+		}
+
+		[TestMethod]
+		public void MethodWithN1ParamsToCallTest()
+		{
+			Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWith1ParamsAndReturnsEnumerableOfT<Model, Model>(Its.Any<Model>()))
+				.ToReturn(() => Enumerable.Empty<Model>());
+
+			_genericMethodsTestInterface.MethodWith1ParamsAndReturnsEnumerableOfT<Model, Model>(new Model());
+		}
+
+		[TestMethod]
+		public void MethodWithN2ParamsToCallTest()
+		{
+			Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWith2ParamsAndReturnsEnumerableOfT<Model, Model, Model>(Its.Any<Model>(), Its.Any<Model>()))
+				.ToReturn(() => Enumerable.Empty<Model>());
+
+			_genericMethodsTestInterface.MethodWith2ParamsAndReturnsEnumerableOfT<Model, Model, Model>(new Model(), new Model());
+		}
+
+		[TestMethod]
+		public void MethodWithNParamsToCallTest()
+		{
+			Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWith3ParamsAndReturnsEnumerableOfT<Model, Model, Model, Model>(Its.Any<Model>(), Its.Any<Model>(), Its.Any<Model>()))
+				.ToReturn(() => Enumerable.Empty<Model>());
+
+			_genericMethodsTestInterface.MethodWith3ParamsAndReturnsEnumerableOfT<Model, Model, Model, Model>(new Model(), new Model(), new Model());
+		}
+	}
+}

--- a/src/Overmock.Tests/OvermockedMock/MethodGenericNoParameters.ToReturn.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/MethodGenericNoParameters.ToReturn.Tests.cs
@@ -1,0 +1,43 @@
+﻿using Overmock.Tests.Mocks;
+
+namespace Overmock.Tests.OvermockedMock
+{
+	public partial class GenericMethodNoParametersTests
+	{
+		[TestMethod]
+		public void MethodWithNoParamsToReturnTest()
+		{
+			Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWithNoParamsAndReturnsEnumerableOfT<Model>())
+				.ToReturn(() => Enumerable.Empty<Model>());
+			
+			_genericMethodsTestInterface.MethodWithNoParamsAndReturnsEnumerableOfT<Model>();
+		}
+
+		[TestMethod]
+		public void MethodWithN1ParamsToReturnTest()
+		{
+            Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWith1ParamsAndReturnsEnumerableOfT<Model, Model>(Its.Any<Model>()))
+				.ToReturn(() => Enumerable.Empty<Model>());
+
+			_genericMethodsTestInterface.MethodWith1ParamsAndReturnsEnumerableOfT<Model, Model>(new Model());
+		}
+
+		[TestMethod]
+		public void MethodWithN2ParamsToReturnTest()
+		{
+			Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWith2ParamsAndReturnsEnumerableOfT<Model, Model, Model>(Its.Any<Model>(), Its.Any<Model>()))
+				.ToReturn(() => Enumerable.Empty<Model>());
+
+			_genericMethodsTestInterface.MethodWith2ParamsAndReturnsEnumerableOfT<Model, Model, Model>(new Model(), new Model());
+		}
+
+		[TestMethod]
+		public void MethodWithNParamsToReturnTest()
+		{
+			Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWith3ParamsAndReturnsEnumerableOfT<Model, Model, Model, Model>(Its.Any<Model>(), Its.Any<Model>(), Its.Any<Model>()))
+				.ToReturn(() => Enumerable.Empty<Model>());
+
+			_genericMethodsTestInterface.MethodWith3ParamsAndReturnsEnumerableOfT<Model, Model, Model, Model>(new Model(), new Model(), new Model());
+		}
+	}
+}

--- a/src/Overmock.Tests/OvermockedMock/MethodWithNoParams.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/MethodWithNoParams.Tests.cs
@@ -1,0 +1,32 @@
+using Overmock.Tests.Mocks;
+using Overmock.Tests.Mocks.Methods;
+
+namespace Overmock.Tests.OvermockedMock
+{
+    [TestClass]
+	public partial class MethodWithNoParamsTests
+	{
+		private readonly Model _model1 = new Model();
+		private readonly Model _model2 = new Model();
+		private readonly List<Model> _models = new List<Model>();
+
+		private IMethodsWithNoParameters _overmock = null!;
+
+		[TestInitialize]
+		public void Initialize()
+		{
+            _overmock = Overmocked.For<IMethodsWithNoParameters>();
+		}
+
+		[TestMethod]
+		public void MethodWith2Params()
+		{
+            Overmocked.Mock(_overmock, p => p.BoolMethodWithNoParams())
+				.ToReturn(true);
+
+			var result = _overmock.BoolMethodWithNoParams();
+
+            Assert.IsTrue(result);
+		}
+	}
+}

--- a/src/Overmock.Tests/OvermockedMock/MethodWithNoParams.ToCall.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/MethodWithNoParams.ToCall.Tests.cs
@@ -1,0 +1,57 @@
+namespace Overmock.Tests.OvermockedMock
+{
+	public partial class MethodWithNoParamsTests
+	{
+		[TestMethod]
+		public void VoidMethodWithNoParamsToCallTest()
+		{
+			var called = false;
+
+			Overmocked.Mock(_overmock, t => t.VoidMethodWithNoParams())
+				.ToCall(c => called = true);
+
+            _overmock.VoidMethodWithNoParams();
+
+			Assert.IsTrue(called);
+		}
+		
+        [TestMethod]
+        public void BoolMethodWithNoParamsToCallTest()
+		{
+			var called = false;
+
+            Overmocked.Mock(_overmock, t => t.BoolMethodWithNoParams())
+				.ToCall(c => called = true);
+
+			_overmock.BoolMethodWithNoParams();
+
+			Assert.IsTrue(called);
+		}
+
+		[TestMethod]
+		public void ModelMethodWithNoParamsToCallTest()
+		{
+			var called = false;
+
+            Overmocked.Mock(_overmock, t => t.ModelMethodWithNoParams())
+				.ToCall(c => called = true);
+
+			_overmock.ModelMethodWithNoParams();
+
+			Assert.IsTrue(called);
+		}
+
+		[TestMethod]
+		public void ListOfModelMethodWithNoParamsToCallTest()
+		{
+			var called = false;
+
+            Overmocked.Mock(_overmock, t => t.ListOfModelMethodWithNoParams())
+				.ToCall(c => called = true);
+
+			_overmock.ListOfModelMethodWithNoParams();
+
+			Assert.IsTrue(called);
+		}
+	}
+}

--- a/src/Overmock.Tests/OvermockedMock/MethodWithNoParams.ToReturn.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/MethodWithNoParams.ToReturn.Tests.cs
@@ -1,0 +1,46 @@
+namespace Overmock.Tests.OvermockedMock
+{
+	public partial class MethodWithNoParamsTests
+	{
+		[TestMethod]
+		public void VoidMethodWithNoParamsToBeCalledTest()
+		{
+            Overmocked.Mock(_overmock, t => t.VoidMethodWithNoParams()).ToBeCalled();
+
+			_overmock.VoidMethodWithNoParams();
+		}
+		
+        [TestMethod]
+        public void BoolMethodWithNoParamsToReturnTest()
+        {
+            Overmocked.Mock(_overmock, t => t.BoolMethodWithNoParams())
+                .ToReturn(true);
+
+            var test = _overmock.BoolMethodWithNoParams();
+
+            Assert.IsTrue(test);
+		}
+
+		[TestMethod]
+		public void ModelMethodWithNoParamsToReturnTest()
+		{
+			Overmocked.Mock(_overmock, t => t.ModelMethodWithNoParams())
+				.ToReturn(_model1);
+
+			var test = _overmock.ModelMethodWithNoParams();
+
+			Assert.AreEqual(_model1, test);
+		}
+
+		[TestMethod]
+		public void ListOfModelMethodWithNoParamsToReturnTest()
+		{
+			Overmocked.Mock(_overmock, t => t.ListOfModelMethodWithNoParams())
+				.ToReturn(_models);
+
+			var test = _overmock.ListOfModelMethodWithNoParams();
+
+			Assert.AreEqual(_models, test);
+		}
+	}
+}

--- a/src/Overmock.Tests/OvermockedMock/MethodWithNoParams.ToThrow.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/MethodWithNoParams.ToThrow.Tests.cs
@@ -1,20 +1,38 @@
-﻿namespace Overmock.Tests.OvermockedMock
+namespace Overmock.Tests.OvermockedMock
 {
-	public partial class PropertyGetTests
+	public partial class MethodWithNoParamsTests
 	{
 		[TestMethod]
-		public void IntPropertyToThrowTest()
+		public void VoidMethodWithNoParamsTest()
 		{
 			var exception = new Exception();
 
-			Overmocked.Mock(_overmock, t => t.Int)
+			Overmocked.Mock(_overmock, t => t.VoidMethodWithNoParams())
 				.ToThrow(exception);
-
-			Assert.IsNotNull(_overmock);
 
 			try
 			{
-				var model = _overmock.Int;
+				_overmock.VoidMethodWithNoParams();
+
+				Assert.Fail();
+			}
+			catch (Exception ex)
+			{
+				Assert.AreEqual(exception, ex);
+			}
+		}
+		
+        [TestMethod]
+        public void BoolMethodWithNoParamsTest()
+		{
+			var exception = new Exception();
+
+			Overmocked.Mock(_overmock, t => t.BoolMethodWithNoParams())
+				.ToThrow(exception);
+
+			try
+			{
+				_overmock.BoolMethodWithNoParams();
 
 				Assert.Fail();
 			}
@@ -25,16 +43,16 @@
 		}
 
 		[TestMethod]
-		public void StringPropertyToThrowTest()
+		public void ModelMethodWithNoParamsTest()
 		{
 			var exception = new Exception();
 
-			Overmocked.Mock(_overmock, t => t.String)
+			Overmocked.Mock(_overmock, t => t.ModelMethodWithNoParams())
 				.ToThrow(exception);
 
 			try
 			{
-				var model = _overmock.String;
+				_overmock.ModelMethodWithNoParams();
 
 				Assert.Fail();
 			}
@@ -45,36 +63,16 @@
 		}
 
 		[TestMethod]
-		public void ModelPropertyToThrowTest()
+		public void ListOfModelMethodWithNoParamsTest()
 		{
 			var exception = new Exception();
 
-			Overmocked.Mock(_overmock, t => t.Model)
+			Overmocked.Mock(_overmock, t => t.ListOfModelMethodWithNoParams())
 				.ToThrow(exception);
 
 			try
 			{
-				var model = _overmock.Model;
-
-				Assert.Fail();
-			}
-			catch (Exception ex)
-			{
-				Assert.AreEqual(exception, ex);
-			}
-		}
-
-		[TestMethod]
-		public void ListOfModelPropertyToThrowTest()
-		{
-			var exception = new Exception();
-
-			Overmocked.Mock(_overmock, t => t.ListOfModels)
-				.ToThrow(exception);
-
-			try
-			{
-				var model = _overmock.ListOfModels;
+				_overmock.ListOfModelMethodWithNoParams();
 
 				Assert.Fail();
 			}

--- a/src/Overmock.Tests/OvermockedMock/PropertyGet.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/PropertyGet.Tests.cs
@@ -1,12 +1,12 @@
 ﻿using Overmock.Tests.Mocks;
 using Overmock.Tests.Mocks.Properties;
 
-namespace Overmock.Tests
+namespace Overmock.Tests.OvermockedMock
 {
     [TestClass]
     public partial class PropertyGetTests
 	{
-		private readonly IOvermock<IPropertiesWithGet> _overmock = Overmocked.Overmock<IPropertiesWithGet>();
+		private readonly IPropertiesWithGet _overmock = Overmocked.For<IPropertiesWithGet>();
 
 		private readonly Model _model1 = new Model();
 		private readonly Model _model2 = new Model();

--- a/src/Overmock.Tests/OvermockedMock/PropertyGet.ToCall.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/PropertyGet.ToCall.Tests.cs
@@ -1,0 +1,61 @@
+﻿namespace Overmock.Tests.OvermockedMock
+{
+	public partial class PropertyGetTests
+	{
+		[TestMethod]
+		public void IntPropertyToCallTest()
+		{
+			var called = false;
+
+            Overmocked.Mock(_overmock, t => t.Int)
+				.ToCall(c => called = true);
+
+            Overmocked.Mock(_overmock, t => t.GetHashCode()).ToBeCalled();
+
+			var model = _overmock.Int;
+
+			Assert.ThrowsException<UnhandledMemberException>(() => _overmock.Equals(null));
+
+			Assert.IsTrue(called);
+		}
+
+		[TestMethod]
+		public void StringPropertyToCallTest()
+		{
+			var called = false;
+
+			Overmocked.Mock(_overmock, t => t.String)
+				.ToCall(c => called = true);
+
+			var model = _overmock.String;
+
+			Assert.IsTrue(called);
+		}
+
+		[TestMethod]
+		public void ModelPropertyToCallTest()
+		{
+			var called = false;
+
+			Overmocked.Mock(_overmock, t => t.Model)
+				.ToCall(c => called = true);
+
+			var model = _overmock.Model;
+
+			Assert.IsTrue(called);
+		}
+
+		[TestMethod]
+		public void ListOfModelPropertyToCallTest()
+		{
+			var called = false;
+
+			Overmocked.Mock(_overmock, t => t.ListOfModels)
+				.ToCall(c => called = true);
+
+			var model = _overmock.ListOfModels;
+
+			Assert.IsTrue(called);
+		}
+	}
+}

--- a/src/Overmock.Tests/OvermockedMock/PropertyGet.ToReturn.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/PropertyGet.ToReturn.Tests.cs
@@ -1,0 +1,49 @@
+﻿namespace Overmock.Tests.OvermockedMock
+{
+	public partial class PropertyGetTests
+	{
+		[TestMethod]
+		public void IntPropertyToReturnTest()
+		{
+			Overmocked.Mock(_overmock, t => t.Int)
+				.ToReturn(20);
+
+			var test = _overmock.Int;
+
+			Assert.AreEqual(20, test);
+		}
+
+		[TestMethod]
+		public void StringPropertyToReturnTest()
+		{
+			Overmocked.Mock(_overmock, t => t.String)
+				.ToReturn("testing-name");
+
+			var test = _overmock.String;
+
+			Assert.AreEqual("testing-name", test);
+		}
+
+		[TestMethod]
+		public void ModelPropertyToReturnTest()
+		{
+			Overmocked.Mock(_overmock, t => t.Model)
+				.ToReturn(_model1);
+
+			var test = _overmock.Model;
+
+			Assert.AreEqual(_model1, test);
+		}
+
+		[TestMethod]
+		public void ListOfModelPropertyToReturnTest()
+		{
+            Overmocked.Mock(_overmock, t => t.ListOfModels)
+				.ToReturn(_models);
+
+			var test = _overmock.ListOfModels;
+
+			Assert.AreEqual(_models, test);
+		}
+	}
+}

--- a/src/Overmock.Tests/OvermockedMock/PropertyGet.ToThrow.Tests.cs
+++ b/src/Overmock.Tests/OvermockedMock/PropertyGet.ToThrow.Tests.cs
@@ -1,4 +1,4 @@
-﻿namespace Overmock.Tests.OvermockedMock
+﻿namespace Overmock.Tests
 {
 	public partial class PropertyGetTests
 	{
@@ -7,14 +7,16 @@
 		{
 			var exception = new Exception();
 
-			Overmocked.Mock(_overmock, t => t.Int)
+			_overmock.Override(t => t.Int)
 				.ToThrow(exception);
 
-			Assert.IsNotNull(_overmock);
+			var target = _overmock.Target;
+
+			Assert.IsNotNull(target);
 
 			try
 			{
-				var model = _overmock.Int;
+				var model = target.Int;
 
 				Assert.Fail();
 			}
@@ -29,12 +31,16 @@
 		{
 			var exception = new Exception();
 
-			Overmocked.Mock(_overmock, t => t.String)
+			_overmock.Override(t => t.String)
 				.ToThrow(exception);
+
+			var target = _overmock.Target;
+
+			Assert.IsNotNull(target);
 
 			try
 			{
-				var model = _overmock.String;
+				var model = target.String;
 
 				Assert.Fail();
 			}
@@ -49,12 +55,16 @@
 		{
 			var exception = new Exception();
 
-			Overmocked.Mock(_overmock, t => t.Model)
+			_overmock.Override(t => t.Model)
 				.ToThrow(exception);
+
+			var target = _overmock.Target;
+
+			Assert.IsNotNull(target);
 
 			try
 			{
-				var model = _overmock.Model;
+				var model = target.Model;
 
 				Assert.Fail();
 			}
@@ -69,12 +79,16 @@
 		{
 			var exception = new Exception();
 
-			Overmocked.Mock(_overmock, t => t.ListOfModels)
+			_overmock.Override(t => t.ListOfModels)
 				.ToThrow(exception);
+
+			var target = _overmock.Target;
+
+			Assert.IsNotNull(target);
 
 			try
 			{
-				var model = _overmock.ListOfModels;
+				var model = target.ListOfModels;
 
 				Assert.Fail();
 			}

--- a/src/Overmock/IOvermock.cs
+++ b/src/Overmock/IOvermock.cs
@@ -40,6 +40,7 @@ namespace Overmock
 		/// <returns>IEnumerable&lt;IPropertyCall&gt;.</returns>
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		IEnumerable<IPropertyCall> GetOvermockedProperties();
+        object GetTarget();
     }
 
 	/// <summary>
@@ -54,5 +55,7 @@ namespace Overmock
 		/// </summary>
 		/// <value>The mocked object.</value>
 		T Target { get; }
+
+        bool Equals(Overmock<T>? obj);
     }
 }

--- a/src/Overmock/IOvermock.cs
+++ b/src/Overmock/IOvermock.cs
@@ -40,6 +40,11 @@ namespace Overmock
 		/// <returns>IEnumerable&lt;IPropertyCall&gt;.</returns>
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		IEnumerable<IPropertyCall> GetOvermockedProperties();
+
+        /// <summary>
+        /// Gets the target.
+        /// </summary>
+        /// <returns>System.Object.</returns>
         object GetTarget();
     }
 
@@ -56,6 +61,11 @@ namespace Overmock
 		/// <value>The mocked object.</value>
 		T Target { get; }
 
+        /// <summary>
+        /// Determines if the provided obj equals this instance.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <returns><c>true</c> if the supplied obj equals this instance, <c>false</c> otherwise.</returns>
         bool Equals(Overmock<T>? obj);
     }
 }

--- a/src/Overmock/Overmock.csproj
+++ b/src/Overmock/Overmock.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.0.5</Version>
+    <Version>0.0.6-RC01</Version>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Adding `Overmocked.For<T>()`, `Overmocked.Mock<T>(T, Expression<Action<T>>)` and `Overmocked.Mock<T, TReturn>(T, Expression<Func<T, TReturn>>)`
Example:
``` C#
        [TestClass]
	public partial class GenericMethodNoParametersTests
	{
		private IGenericMethodsTestInterface _genericMethodsTestInterface = null!;

		[TestInitialize]
		public void Initialize()
		{
			_genericMethodsTestInterface = Overmocked.For<IGenericMethodsTestInterface>();
		}

		[TestMethod]
		public void TestWithGenericParametersOnMethod()
		{
			var expected = new List<Model> { new  Model() };

            Overmocked.Mock(_genericMethodsTestInterface, m => m.MethodWithNoParamsAndReturnsEnumerableOfT<Model>())
				.ToReturn(expected);

			var actual = _genericMethodsTestInterface.MethodWithNoParamsAndReturnsEnumerableOfT<Model>();
			Assert.IsTrue(true);
			Assert.IsNotNull(actual);
			CollectionAssert.AreEqual(expected, actual.ToList());
		}
	}
```